### PR TITLE
Add cross-building against Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 organization in ThisBuild := "com.streetcontxt"
 scalaVersion in ThisBuild := "2.11.8"
+crossScalaVersions in ThisBuild := Seq("2.11.8", "2.12.4")
 licenses in ThisBuild += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 bintrayOrganization in ThisBuild := Some("streetcontxt")
 

--- a/src/main/scala/com/contxt/kinesis/ScalaKinesisProducer.scala
+++ b/src/main/scala/com/contxt/kinesis/ScalaKinesisProducer.scala
@@ -49,7 +49,7 @@ object ScalaKinesisProducer {
     val callback = new Runnable {
       override def run(): Unit = promise.tryComplete(Try(listenable.get()))
     }
-    listenable.addListener(callback, global)
+    listenable.addListener(callback, ExecutionContext.global)
     promise.future
   }
 }


### PR DESCRIPTION
In order to upgrade https://github.com/StreetContxt/lagom-kinesis to work with Lagom 1.4/Scala 2.12, support for cross-building against Scala 2.12 needs to be added to this library.

Only one small code change was required, due to the fact that the type of scala.concurrent.ExecutionContext.Implicits.global has been changed in Scala 2.12 so it no longer directly implements java.util.concurrent.Executor.  The change is backwards compatible with Scala 2.11 and the library can be cross-compiled/published against both.