### PR TITLE
Fixed installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ interacting with KPL.
 
 ```
 resolvers in ThisBuild += Resolver.bintrayRepo("streetcontxt", "maven")
-libraryDependencies += "com.contxt" %% "kpl-scala" % "1.0.4"
+libraryDependencies += "com.streetcontxt" %% "kpl-scala" % "1.0.5"
 ```
 
 


### PR DESCRIPTION
The organisation key was incorrect under installation instructions. Also updated version of the artifact.